### PR TITLE
feat: add bitbucket-cli (bkt) package

### DIFF
--- a/configuration.nix
+++ b/configuration.nix
@@ -125,6 +125,7 @@
     pkgs.ffmpeg
     (pkgs.callPackage ./packages/st { })
     (unstable.callPackage ./packages/claude.nix { })
+    (pkgs.callPackage ./packages/bitbucket-cli.nix { })
   ];
 
   fonts.packages = with pkgs; [

--- a/packages/bitbucket-cli.nix
+++ b/packages/bitbucket-cli.nix
@@ -1,0 +1,24 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "bitbucket-cli";
+  version = "0.17.0";
+
+  src = fetchFromGitHub {
+    owner = "avivsinai";
+    repo = "bitbucket-cli";
+    rev = "v${version}";
+    hash = "sha256-Hn8FS9+SVmabBOwqT2XpqoxKououNnW75THcGx4nYtA=";
+  };
+
+  vendorHash = "sha256-6H4+CHSXJYRDlx12Iz9R129VIiA0NB/5g7JMgGwYwkE=";
+
+  subPackages = [ "cmd/bkt" ];
+
+  meta = {
+    description = "Bitbucket CLI tool";
+    homepage = "https://github.com/avivsinai/bitbucket-cli";
+    license = lib.licenses.mit;
+    mainProgram = "bkt";
+  };
+}


### PR DESCRIPTION
## Summary
- Adds custom Go derivation for `bitbucket-cli` v0.17.0 (not in nixpkgs)
- Installs `bkt` binary via `environment.systemPackages`
- Hashes resolved and build verified locally

## Test plan
- [x] `nix build` succeeds with correct source and vendor hashes
- [x] `make rebuild` completes successfully
- [ ] `bkt --help` prints CLI usage after switch