### PR TITLE
feat(claude-commands): wait for CI checks in commit-push-pr

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,3 +26,7 @@
 
 - Never git commit or push
 - Do not create git branches
+- Don't make changes to the system directly. Make them to the nixos configuration so that the change is made for all applies going forward.
+
+## Testing
+- Test with make rebuild and ensure it completes succesfully

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/packages/claude-commands.nix
+++ b/packages/claude-commands.nix
@@ -10,7 +10,13 @@
     1. Add all unstaged changes to git
     2. Commit with a relevant commit message (using conventional commits)
     3. Push changes
-    4. Open a pull request
+    4. Open a pull request (or reuse the existing one for the branch)
+    5. Wait for CI/CD checks to finish using `gh pr checks <pr-url-or-number> --watch --fail-fast`
+       - This blocks until all required checks complete; exits 0 on success, non-zero on any failure
+       - If the repo has no checks configured, this exits immediately — treat as success
+    6. Report the result:
+       - On success: PR URL and a brief summary of which checks ran
+       - On failure: name the failing check(s) and include `gh run view <run-id> --log-failed` output so the user can debug without leaving the terminal
 
     **Conventional Commit Standards:**
     - Branch names: `feat/description`, `fix/description`, `docs/description`, etc.
@@ -25,5 +31,6 @@
     - If the PR already exists you can just push the changes to that PR
     - Do not use a browser just shell tools
     - Never commit to master
+    - The CI watch step in (5) is long-running — a brief "waiting on CI…" status line before it and a final result line after are fine; otherwise no extra commentary
   '';
 }

--- a/packages/peon-ping.nix
+++ b/packages/peon-ping.nix
@@ -12,7 +12,7 @@
     #annoyed_threshold = 1;
     #annoyed_window_seconds = 10;
     categories = {
-      "session.start" = false;
+      "session.start" = true;
       "session.end" = true;
       "task.complete" = true;
       "task.acknowledge" = true;


### PR DESCRIPTION
## Summary
- Extends `/commit-push-pr` to block on `gh pr checks --watch --fail-fast` after PR creation, so a successful command return implies green CI
- On failure, surfaces failing check name(s) and `gh run view --log-failed` output
- Bundles small dev-config touch-ups: AGENTS.md guidance, CLAUDE.md symlink, peon-ping `session.start` toggle

## Test plan
- [ ] `make rebuild` succeeds and `~/.claude/commands/commit-push-pr.md` reflects the new wait-for-CI steps
- [ ] Run `/commit-push-pr` on a scratch branch — confirm it blocks on CI and reports pass/fail